### PR TITLE
Added ofxGLEditor and ofxScheme

### DIFF
--- a/mosaic_installer.sh
+++ b/mosaic_installer.sh
@@ -351,6 +351,22 @@ else
   git clone --branch=master https://github.com/d3cod3/ofxWarp
 fi
 
+if [ -d ofxGLEditor ]; then
+  echo -e "\nUpdating ofxGLEditor addon..."
+  cd ofxWarp && git checkout -- . && git pull && cd ..
+else
+  echo -e "\nCloning ofxGLEditor addon..."
+  git clone --branch=master https://github.com/Akira-Hayasaka/ofxGLEditor
+fi
+
+if [ -d ofxScheme ]; then
+  echo -e "\nUpdating ofxScheme addon..."
+  cd ofxWarp && git checkout -- . && git pull && cd ..
+else
+  echo -e "\nCloning ofxScheme addon..."
+  git clone --branch=master https://github.com/d3cod3/ofxScheme
+fi
+
 # 5 - Compile & install opendht library
 cd $INSTALLFOLDER/$OFFOLDERNAME/addons/ofxOpenDHT
 git clone https://github.com/savoirfairelinux/opendht.git


### PR DESCRIPTION
Hi,

I have a fresh installation of PopOS, which is based on Ubuntu.

I noticed that ofxGLEditor and ofxScheme were missing, and it caused an error when building OpenDHT.

I added the following lines to the mosaic_installer.sh script just before step 5, 'Compile & Install OpenDHT Library,' and then I was able to install it successfully.

I'm not sure if this is an error specific to PopOS, but I figured it couldn't hurt to have them. Let me know what you think.